### PR TITLE
Make the requirements for loading configs less dumb

### DIFF
--- a/config_test_cases.md
+++ b/config_test_cases.md
@@ -9,11 +9,8 @@ Setup:
 Expectations:
 
 - A default config is created in memory
-  - `logging_level` is default
-  - `environment` is default
-- Default environmental variable keys are used
-  - `YOLK_ENVIRONMENT` is used to label environment and load additional configs
-  - `YOLK_LOGGING_LEVEL` is used to set logging level
+  - `logging_level` is default (debug)
+  - `environment` is default (empty)
 
 `example.py`
 
@@ -31,7 +28,7 @@ Setup:
 - `application.ini` exists
 - `application_prod.ini` exits
 - `ENVIRONMENT=prod` set in environment vars
-- Change environment variable housing environment name to `ENVIRONMENT`
+- environment is interpolated to prod
 
 Expectations:
 
@@ -39,17 +36,14 @@ Expectations:
 - Yolk will load the prod `application_prod.ini` config
 - `logging_level` is "ERROR"
 - `environment` is "prod"
+- config is loaded on instantiation
 
 `application.ini`
 
 ```ini
 [DEFAULT]
 logging_level = DEBUG
-environment =
-
-[ENVIRONMENT_VARIABLES]
-yolk_environment = ENVIRONMENT
-yolk_logging_level = YOLK_LOGGING_LEVEL
+environment = {{ENVIRONMENT}}
 ```
 
 `application_prod.ini`

--- a/src/runtime_yolk/config_loader.py
+++ b/src/runtime_yolk/config_loader.py
@@ -2,25 +2,17 @@
 from __future__ import annotations
 
 import os
+import re
 from configparser import ConfigParser
 from pathlib import Path
 
 from runtime_yolk.util.file_rule import get_file_name
 
-DEFAULT_DEFAULT = {
-    "environment": "",
-    "logging_level": "DEBUG",
-}
-DEFAULT_ENVIROMENT_VARIABLES = {
-    "environment": "YOLK_ENVIRONMENT",
-    "logging_level": "YOLK_LOGGING_LEVEL",
-}
+INTERPOLATE_PATTERN = "{{(.+?)}}"
 
 
 class ConfigLoader:
     """Load and store configuration data"""
-
-    yolk_environment_key = "YOLK_ENVIRONMENT"
 
     def __init__(self, *, working_directory: Path | None = None) -> None:
         """
@@ -30,76 +22,65 @@ class ConfigLoader:
             working_directory: Set the working directory where file(s) will be loaded.
         """
         self._working_directory = working_directory or Path().cwd()
+        self._config = ConfigParser(interpolation=None)
 
-        # Build and populate the default config. Values will be replaced by any
-        # loaded configurations.
-        self._config = ConfigParser()
-        self._config["DEFAULT"] = DEFAULT_DEFAULT
-        self._config["ENVIRONMENT_VARIABLES"] = DEFAULT_ENVIROMENT_VARIABLES
+        self._build_default_config()
 
-        self._environment = self._fetch_environment()
         # Store loaded config file names to prevent loading the same file twice.
-        self._loaded_configs: set[str] = set()
+        self._loaded_configs: set[Path] = set()
+
+    def _build_default_config(self) -> None:
+        """Build and populate the default config."""
+        self._config["DEFAULT"] = {
+            "environment": "",
+            "logging_level": "DEBUG",
+        }
 
     def load(
         self,
         *,
         config_name: str = "application",
-        load_additional: bool = True,
     ) -> None:
         """
         Load configuration data from a file, layers loads onto existing loaded data.
 
-        Looks for the `${config_name}.ini` in the working directory. After loading
-        the config_name, if `load_additional`, the environment value is appended
-        to the filename before the file extension. e.g. `yolk_application.ini` becomes
-        `yolk_application_${yolk_environment}.ini`. If found, this config is
-        loaded next.
+        Looks for the `${config_name}.ini` in the working directory. After loading the
+        config_name the environment value is appended to the filename before the file
+        extension. e.g. `application.ini` becomes `application_${environment}.ini`. If
+        found, this config is loaded next.
+
+        Default ConfigParser interpolation is disabled. Values with the pattern of
+        `{{KEYWORD}}` are interpolated a single time against matching environ keys.
+        Keywords are case sensitive.
 
         Args:
             config_name: The name of the configuration file without the extension.
-            load_additional: When true, environment labeled configurations are loaded.
         """
-        self._load(config_name, "", load_additional)
+        self._load(config_name, "")
 
-    def _fetch_environment(self) -> str:
-        """Get environment value from config, environ, or return empty string."""
-        config_env = self._config.get("DEFAULT", "environment", fallback="")
-        return config_env or os.getenv(self.yolk_environment_key) or ""
-
-    def _update_environment_key(self) -> None:
-        """Update the key for environment variable values from loaded config."""
-        self.yolk_environment_key = self._config.get(
-            section="ENVIRONMENT_VARIABLES",
-            option="yolk_environment",
-            fallback=self.yolk_environment_key,
-        )
-
-    def _load(
-        self,
-        config_file: str,
-        yolk_environment: str,
-        load_additional: bool,
-    ) -> None:
+    def _load(self, config_file: str, yolk_environment: str) -> None:
         """Interal recursive loader."""
 
         _file = self._working_directory / get_file_name(config_file, yolk_environment)
 
-        if _file.is_file() and str(_file) not in self._loaded_configs:
-            # Load the discovered file as a configuration file
-            # ConfigParser handles invalid files
-            self._config.read(_file)
+        if _file.is_file() and _file not in self._loaded_configs:
+            contents = self._interpolate_environment(_file.read_text())
 
-            # Update the environ key value to match newly loaded config
-            self._update_environment_key()
-
-            # Update internal attributes (must be done after _update_environment_key())
-            self._loaded_configs.add(str(_file))
-            self._environment = self._fetch_environment()
+            # Load the discovered content as a configuration string
+            # ConfigParser handles invalid content
+            self._config.read_string(contents)
+            self._loaded_configs.add(_file)
 
             # If the config file has an environment set, attempt to load the next file.
-            if load_additional and self._environment:
-                self._load(config_file, self._environment, load_additional)
+            if self._config.get("DEFAULT", "environment", fallback=None):
+                self._load(config_file, self._config.get("DEFAULT", "environment"))
+
+    def _interpolate_environment(self, contents: str) -> str:
+        """Interpolate {{keywords}} to matching environment variable values."""
+        for match in re.finditer(INTERPOLATE_PATTERN, contents):
+            if match.group(1) in os.environ:
+                contents = re.sub(match.group(0), os.environ[match.group(1)], contents)
+        return contents
 
     def get_config(self) -> ConfigParser:
         """Get the config object."""

--- a/tests/fixtures/default_and_env_config/application-prod.ini
+++ b/tests/fixtures/default_and_env_config/application-prod.ini
@@ -1,6 +1,2 @@
 [DEFAULT]
-# All loggers will inherit this level
 logging_level = ERROR
-
-# Usually empty for default configuration and set in environment specific configuration files.
-environment = prod

--- a/tests/fixtures/default_and_env_config/application.ini
+++ b/tests/fixtures/default_and_env_config/application.ini
@@ -1,12 +1,3 @@
 [DEFAULT]
-# All loggers will inherit this level
 logging_level = DEBUG
-
-# Usually empty for default configuration and set in environment specific configuration files.
-environment =
-
-[ENVIRONMENT_VARIABLES]
-# Set the environment variable names to use for the application.
-# These can be adjusted to match existing environment variables if desired.
-yolk_environment = ENVIRONMENT
-yolk_logging_level = YOLK_LOGGING_LEVEL
+environment = {{ENVIRONMENT}}


### PR DESCRIPTION
This simplifies the loading requirements of the config files. We remove
the dumb layer of pulling custom environment variable keys to interprete
from the config file itself and streamline the process.
`application.ini` is the default file looked for unless defined
otherwise at runtime. `{{keywords}}` are interpolated against environ
values, if matched, on load.  ConfigParser interpolation is disabled as
it causes nothing but issues with tokens and keys which commonly
containt the `%` interpolation character.