### PR TITLE
Default config values pulled from environ

### DIFF
--- a/src/runtime_yolk/config_loader.py
+++ b/src/runtime_yolk/config_loader.py
@@ -32,8 +32,8 @@ class ConfigLoader:
     def _build_default_config(self) -> None:
         """Build and populate the default config."""
         self._config["DEFAULT"] = {
-            "environment": "",
-            "logging_level": "ERROR",
+            "environment": os.getenv("ENVIRONMENT", ""),
+            "logging_level": os.getenv("LOGGING_LEVEL", "ERROR"),
             "logging_format": "%(asctime)s - %(levelname)s - %(name)s - %(message)s",
         }
 

--- a/tests/yolk_test.py
+++ b/tests/yolk_test.py
@@ -4,12 +4,20 @@ import logging
 import os
 from configparser import NoOptionError
 from pathlib import Path
+from typing import Generator
+from unittest.mock import patch
 
 import pytest
 from _pytest.logging import LogCaptureFixture
 from runtime_yolk import Yolk
 
 FIXTURE_PATH = "tests/fixtures/yolk_test"
+
+
+@pytest.fixture(autouse=True)
+def patch_environ() -> Generator[None, None, None]:
+    with patch.dict(os.environ, {}):
+        yield None
 
 
 def test_working_directory_attr_unset() -> None:


### PR DESCRIPTION
`environment` is pulled from `ENVIRONMENT` or defaults to `""`

`logging_level` is pulled from `LOGGING_LEVEL` or defaults to `"ERROR"` to match `logging` default

