### PR TITLE
pre-commit updates with formatting changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,39 +10,25 @@ repos:
       - id: end-of-file-fixer
       - id: check-docstring-first
       - id: debug-statements
+      - id: mixed-line-ending
 
-  # Adds a standard feel to import segments, adds future annotations
-  - repo: https://github.com/asottile/reorder-python-imports
-    rev: v3.12.0
+  # Adds a standard feel to import segments
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
     hooks:
-      - id: reorder-python-imports
+      - id: isort
         args:
-          - "--py37-plus"
+          - "--force-single-line-imports"
           - "--add-import"
           - "from __future__ import annotations"
-          - "--application-directories"
-          - ".:src"
-
-  # Automatically upgrade syntax to newer versions
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args:
-          - "--py38-plus"
+          - "--profile"
+          - "black"
 
   # Format code. No, I don't like everything black does either.
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.1.1
     hooks:
       - id: black
-
-  # Format docs.
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black>=23.3.0]
 
   # Flake8 for linting, line-length adjusted to match Black default
   - repo: https://github.com/PyCQA/flake8

--- a/src/runtime_yolk/config_loader.py
+++ b/src/runtime_yolk/config_loader.py
@@ -1,4 +1,5 @@
 """Load and store configuration data"""
+
 from __future__ import annotations
 
 import os

--- a/src/runtime_yolk/env_loader.py
+++ b/src/runtime_yolk/env_loader.py
@@ -10,6 +10,7 @@ the following order:
 - Matched leading/trailing single quotes or double quotes will be
   stripped from values (not keys).
 """
+
 from __future__ import annotations
 
 import os

--- a/src/runtime_yolk/yolk.py
+++ b/src/runtime_yolk/yolk.py
@@ -3,6 +3,7 @@ Main class for runtime-yolk.
 
 Reponsible for all loaders and runners.
 """
+
 from __future__ import annotations
 
 import logging

--- a/tests/env_loader_test.py
+++ b/tests/env_loader_test.py
@@ -1,4 +1,5 @@
 """Unit tests for .env file loader"""
+
 from __future__ import annotations
 
 import os
@@ -10,7 +11,6 @@ from unittest.mock import patch
 import pytest
 
 from runtime_yolk import env_loader
-
 
 ENV_FILE_CONTENTS = [
     "SECRETBOX_TEST_PROJECT_ENVIRONMENT=sandbox",


### PR DESCRIPTION
black 24.1 formatting changes

Do to conflicts against the format of `black`, the tool `reorder-python-imports` is replaced with `isort`.

Removing `pyupgrade` to reduce tool opinionation further.